### PR TITLE
Kill the timer either way

### DIFF
--- a/unoccupied_vehicle_never_respawns_on_death_fix.inc
+++ b/unoccupied_vehicle_never_respawns_on_death_fix.inc
@@ -35,11 +35,9 @@ static ptmRespawnUnoccupiedVehicle[MAX_VEHICLES];
 
 stock Hook_SetVehicleHealth(vehicleid, Float:health)
 {
+	KillTimer(ptmRespawnUnoccupiedVehicle[vehicleid]);
 	if(health < 250.0)
-	{
-		KillTimer(ptmRespawnUnoccupiedVehicle[vehicleid]);
 		ptmRespawnUnoccupiedVehicle[vehicleid] = SetTimerEx("RespawnUnoccupiedVehicle", 13000, false, "i", vehicleid);
-	}
 	return SetVehicleHealth(vehicleid, health);
 }
 


### PR DESCRIPTION
This will kill the timer each time SetVehicleHealth is used. The way it was before would cause the vehicle to respawn if you have set the vehicle health back to a value above 250 after it has been set to a value below 250.
